### PR TITLE
refactor / move navigation-logic to `<Scanner/>`-screen

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -254,21 +254,21 @@ PODS:
     - React-jsi (= 0.64.1)
     - React-perflogger (= 0.64.1)
   - React-jsinspector (0.64.1)
-  - react-native-camera (4.0.3):
+  - react-native-camera (4.2.1):
     - React-Core
-    - react-native-camera/RCT (= 4.0.3)
-    - react-native-camera/RN (= 4.0.3)
-  - react-native-camera/RCT (4.0.3):
+    - react-native-camera/RCT (= 4.2.1)
+    - react-native-camera/RN (= 4.2.1)
+  - react-native-camera/RCT (4.2.1):
     - React-Core
-  - react-native-camera/RN (4.0.3):
+  - react-native-camera/RN (4.2.1):
     - React-Core
   - react-native-randombytes (3.6.1):
     - React-Core
-  - react-native-safe-area-context (3.3.0):
+  - react-native-safe-area-context (3.3.2):
     - React-Core
   - react-native-sqlite-storage (5.0.0):
     - React
-  - react-native-webview (11.13.0):
+  - react-native-webview (11.14.0):
     - React-Core
   - React-perflogger (0.64.1)
   - React-RCTActionSheet (0.64.1):
@@ -334,9 +334,9 @@ PODS:
     - React-cxxreact (= 0.64.1)
     - React-jsi (= 0.64.1)
     - React-perflogger (= 0.64.1)
-  - RNBootSplash (3.2.5):
+  - RNBootSplash (3.2.6):
     - React-Core
-  - RNCAsyncStorage (1.15.6):
+  - RNCAsyncStorage (1.15.9):
     - React-Core
   - RNCMaskedView (0.1.11):
     - React
@@ -344,7 +344,7 @@ PODS:
     - React-Core
   - RNPermissions (3.0.5):
     - React-Core
-  - RNReanimated (2.2.0):
+  - RNReanimated (2.2.2):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -373,7 +373,7 @@ PODS:
     - React-RCTVibration
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (3.5.0):
+  - RNScreens (3.8.0):
     - React-Core
     - React-RCTImage
   - RNSVG (12.1.1):
@@ -553,7 +553,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
-  FBReactNativeSpec: 65dcccaa0d44f728f230f4dd7a9b7850049d6806
+  FBReactNativeSpec: bce04181e51940006a67ec65611531649cea788c
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: 755929a4f851b2fb2c347d533a23f191b008554c
@@ -576,11 +576,11 @@ SPEC CHECKSUMS:
   React-jsi: 5de8204706bd872b78ea646aee5d2561ca1214b6
   React-jsiexecutor: 124e8f99992490d0d13e0649d950d3e1aae06fe9
   React-jsinspector: 500a59626037be5b3b3d89c5151bc3baa9abf1a9
-  react-native-camera: a6055b8538d741b5ac221fa73c866c526010c8c9
+  react-native-camera: 3eae183c1d111103963f3dd913b65d01aef8110f
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
-  react-native-safe-area-context: 61c8c484a3a9e7d1fda19f7b1794b35bbfd2262a
+  react-native-safe-area-context: 584dc04881deb49474363f3be89e4ca0e854c057
   react-native-sqlite-storage: 418ef4afc5e6df6ce3574c4617e5f0b65cffde55
-  react-native-webview: 133a6a5149f963259646e710b4545c67ef35d7c9
+  react-native-webview: d70bc760daaa0e2667dec569b93014882565819c
   React-perflogger: aad6d4b4a267936b3667260d1f649b6f6069a675
   React-RCTActionSheet: fc376be462c9c8d6ad82c0905442fd77f82a9d2a
   React-RCTAnimation: ba0a1c3a2738be224a08092fa7f1b444ab77d309
@@ -593,17 +593,17 @@ SPEC CHECKSUMS:
   React-RCTVibration: 4b99a7f5c6c0abbc5256410cc5425fb8531986e1
   React-runtimeexecutor: ff951a0c241bfaefc4940a3f1f1a229e7cb32fa6
   ReactCommon: bedc99ed4dae329c4fcf128d0c31b9115e5365ca
-  RNBootSplash: 75faf048f66eebe1650e91afdb8c2205fefc1870
-  RNCAsyncStorage: b7c6564ce662366dd44d0189456183ef7eda2d4d
+  RNBootSplash: 51eef7e143faeab63f81ddbb7c1de38b8fba66ed
+  RNCAsyncStorage: 26f25150da507524a7815f2ada06ca0967f65633
   RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNPermissions: 7043bacbf928eae25808275cfe73799b8f618911
-  RNReanimated: 9c13c86454bfd54dab7505c1a054470bfecd2563
-  RNScreens: 01ab149b5dd5c27f5ff26741b1d2bdf2cee1af35
+  RNReanimated: 241c586663f44f19a53883c63375fdd041253960
+  RNScreens: 6e1ea5787989f92b0671049b808aef64fa1ef98c
   RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f
   Yoga: a7de31c64fe738607e7a3803e3f591a4b1df7393
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: d30bae527f552faeaa4d3a26d6163a77d74df391
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.2

--- a/ios/identityWallet.xcodeproj/project.pbxproj
+++ b/ios/identityWallet.xcodeproj/project.pbxproj
@@ -576,7 +576,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -641,7 +641,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/src/components/scanner/Scanner.tsx
+++ b/src/components/scanner/Scanner.tsx
@@ -10,12 +10,8 @@ export const Scanner = () => {
         useContext(Context);
 
     async function onInput(maybeURI: any) {
-        if (isTest) {
-            maybeURI =
-                "wc:f164ac0d5020e5d61ea66fd6984dd29feb0152415b733b06651126c5089861c4@2?controller=false&publicKey=f863cebfebe3255b08c4697923fd3ced9d0f2bfecb1c22da48decb1e4cc0d81d&relay=%7B%22protocol%22%3A%22waku%22%7D";
-        }
-
         console.log("onRead", maybeURI);
+
         if (typeof maybeURI !== "string") {
             console.warn("typeof maybeURI !== 'string': ", maybeURI);
             return;
@@ -38,16 +34,15 @@ export const Scanner = () => {
                 return;
             }
             navigateBankID();
-            return;
+        } else {
+            try {
+                await pair(URI);
+            } catch (err) {
+                console.warn("ERROR: await pair(URI): ", err);
+                return;
+            }
+            navigateHome();
         }
-
-        try {
-            await pair(URI);
-        } catch (err) {
-            console.warn("ERROR: await pair(URI): ", err);
-            return;
-        }
-        navigateHome();
     }
 
     return (

--- a/src/components/scanner/Scanner.tsx
+++ b/src/components/scanner/Scanner.tsx
@@ -10,8 +10,11 @@ export const Scanner = () => {
         useContext(Context);
 
     async function onInput(maybeURI: any) {
-        maybeURI =
-            "wc:f164ac0d5020e5d61ea66fd6984dd29feb0152415b733b06651126c5089861c4@2?controller=false&publicKey=f863cebfebe3255b08c4697923fd3ced9d0f2bfecb1c22da48decb1e4cc0d81d&relay=%7B%22protocol%22%3A%22waku%22%7D";
+        if (isTest) {
+            maybeURI =
+                "wc:f164ac0d5020e5d61ea66fd6984dd29feb0152415b733b06651126c5089861c4@2?controller=false&publicKey=f863cebfebe3255b08c4697923fd3ced9d0f2bfecb1c22da48decb1e4cc0d81d&relay=%7B%22protocol%22%3A%22waku%22%7D";
+        }
+
         console.log("onRead", maybeURI);
         if (typeof maybeURI !== "string") {
             console.warn("typeof maybeURI !== 'string': ", maybeURI);

--- a/src/components/scanner/Scanner.tsx
+++ b/src/components/scanner/Scanner.tsx
@@ -34,7 +34,7 @@ export const Scanner = () => {
             if (!client) {
                 throw Error("WalletConnect client not initialized");
             }
-            const pairResult = await pair(uri, true);
+            const pairResult = await pair(uri);
             console.debug("pairResult", pairResult);
         } catch (error) {
             throw error;

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -89,7 +89,9 @@ export interface IContext {
         args: FindArgs<TCredentialColumns>
     ) => Promise<UniqueVerifiableCredential[]>;
     saveVP: (vp: VerifiablePresentation | string) => Promise<string>;
-    pair: (uri: string, requireTrustedIdentity: boolean) => Promise<void>;
+    pair: (uri: string) => Promise<void>;
+    pairCached: (uri: string) => Promise<void>;
+    hasTrustedIdentity: boolean;
 }
 
 export const Context = createContext<IContext>(undefined!);
@@ -114,9 +116,9 @@ export const ContextProvider = (props: any) => {
             })
     );
     const veramo = useVeramo(selectedChain);
-    const [hasTrustedIndentity, setHasTrustedIndentity] =
+    const [hasTrustedIdentity, setHasTrustedIdentity] =
         useState<boolean>(false);
-    const walletconnect = useWalletconnect(chains, veramo, hasTrustedIndentity);
+    const walletconnect = useWalletconnect(chains, veramo, hasTrustedIdentity);
 
     // Loading
     useEffect(() => {
@@ -155,9 +157,9 @@ export const ContextProvider = (props: any) => {
     //                         vc.verifiableCredential.credentialSubject
     //                     );
     //                 });
-    //                 console.info("hasTrustedIndentity", !!hasRegistered);
+    //                 console.info("hasTrustedIdentity", !!hasRegistered);
     //                 if (subscribed) {
-    //                     setHasTrustedIndentity(!!hasRegistered);
+    //                     setHasTrustedIdentity(!!hasRegistered);
     //                 }
     //             }
     //         }
@@ -197,9 +199,9 @@ export const ContextProvider = (props: any) => {
                             vc.verifiableCredential.credentialSubject
                         );
                     });
-                    console.info("hasTrustedIndentity", !!hasRegistered);
+                    console.info("hasTrustedIdentity", !!hasRegistered);
                     if (subscribed) {
-                        setHasTrustedIndentity(!!hasRegistered);
+                        setHasTrustedIdentity(!!hasRegistered);
                     }
                 }
             }
@@ -217,6 +219,7 @@ export const ContextProvider = (props: any) => {
         chains,
         provider,
         selectedChain,
+        hasTrustedIdentity,
         ...walletconnect,
         ...veramo,
     };

--- a/src/hooks/useNavigation.ts
+++ b/src/hooks/useNavigation.ts
@@ -1,0 +1,16 @@
+import { useNavigation } from "@react-navigation/core";
+
+export const SCREEN_BANKID = "Bankid";
+export const SCREEN_HOME = "Main";
+
+export function useLocalNavigation() {
+    const navigation = useNavigation();
+
+    const navigateBankID = () => navigation.navigate(SCREEN_BANKID);
+    const navigateHome = () => navigation.navigate(SCREEN_HOME);
+
+    return {
+        navigateBankID,
+        navigateHome,
+    };
+}

--- a/src/navigation.tsx
+++ b/src/navigation.tsx
@@ -5,6 +5,7 @@ import { useContext } from "react";
 import { Icon, IconType } from "./assets/icons/Icon";
 import { ColorContext } from "./colorContext";
 import { Context } from "./context";
+import { SCREEN_BANKID, SCREEN_HOME } from "./hooks/useNavigation";
 import { BankId } from "./screens/BankId";
 import { Home } from "./screens/Home";
 import { Identity } from "./screens/Identity";
@@ -82,7 +83,7 @@ export const Navigation = () => {
     return (
         <Stack.Navigator>
             <Stack.Screen
-                name="Main"
+                name={SCREEN_HOME}
                 component={Tabs}
                 options={{ headerShown: false }}
             />
@@ -97,7 +98,7 @@ export const Navigation = () => {
                 }}
             />
             <Stack.Screen
-                name="Bankid"
+                name={SCREEN_BANKID}
                 component={BankId}
                 options={{ title: "BankID" }}
             />

--- a/src/screens/BankId.tsx
+++ b/src/screens/BankId.tsx
@@ -70,7 +70,6 @@ export const BankId = () => {
                     setTimeout(() => resolve(true), 2000);
                 });
                 await sleep;
-                //checkCachedPairingsAndPair();
                 setLoading(false);
                 goBack();
             })
@@ -80,25 +79,6 @@ export const BankId = () => {
                 setLoading(false);
                 setBankidToken("");
             });
-    };
-
-    const checkCachedPairingsAndPair = () => {
-        if (!!cachedPairing) {
-            const initiatedPairingTime = cachedPairing.timeInitiated;
-            const now = Date.now();
-            const ellapsedTime = now - initiatedPairingTime;
-            // 5min
-            if (ellapsedTime > 300000) {
-                Toast.show({
-                    type: "info",
-                    text1: "Pairing request is outdated. Please pair again",
-                    topOffset: 100,
-                    position: "top",
-                });
-            } else {
-                pair(cachedPairing.uri, true);
-            }
-        }
     };
 
     // Use authVC to register

--- a/src/utils/useWalletconnect.ts
+++ b/src/utils/useWalletconnect.ts
@@ -108,30 +108,24 @@ export const useWalletconnect = (
         }
     }, [requests, proposals]);
 
+    const pairCached = (uri: string) => {
+        const initiatedTime = Date.now();
+        const cachedPairing: CachedPairing = {
+            uri: uri,
+            timeInitiated: initiatedTime,
+        };
+
+        setCachedPairing(cachedPairing);
+        console.log("In Pair and cachedPairing is set");
+        console.log(cachedPairing);
+    };
+
     const pair = async (uri: string) => {
         console.log(`pair(): Uri: ${uri}`);
         console.log(`Has trusted identity: ${hasTrustedIdentity}`);
-        if (!hasTrustedIdentity) {
-            const initiatedTime = Date.now();
-            const cachedPairing: CachedPairing = {
-                uri: uri,
-                timeInitiated: initiatedTime,
-            };
-
-            setCachedPairing(cachedPairing);
-            console.log("In Pair and cachedPairing is set");
-            console.log(cachedPairing);
-            navigate("Bankid");
-        } else {
-            try {
-                const pairResult = await client?.pair({ uri: uri });
-                console.log("pari", pairResult);
-                navigate("Home");
-                console.log("PairResult", pairResult);
-            } catch (e: any) {
-                console.log(e);
-            }
-        }
+        const pairResult = await client?.pair({ uri: uri });
+        console.log("pari", pairResult);
+        console.log("PairResult", pairResult);
     };
 
     const handleRequest = useCallback(
@@ -385,5 +379,6 @@ export const useWalletconnect = (
         setRequests,
         cachedPairing,
         pair,
+        pairCached,
     };
 };

--- a/src/utils/useWalletconnect.ts
+++ b/src/utils/useWalletconnect.ts
@@ -69,7 +69,7 @@ export const useWalletconnect = (
             return;
         }
 
-        pair(cachedPairing.uri, true);
+        pair(cachedPairing.uri);
     }, [hasTrustedIdentity, cachedPairing]);
 
     // Init Walletconnect client
@@ -108,12 +108,10 @@ export const useWalletconnect = (
         }
     }, [requests, proposals]);
 
-    const pair = async (uri: string, requireTrustedIdentity: boolean) => {
-        console.log(
-            `In pair. Uri: ${uri}, requireTrustedIdentity: ${requireTrustedIdentity}`
-        );
+    const pair = async (uri: string) => {
+        console.log(`pair(): Uri: ${uri}`);
         console.log(`Has trusted identity: ${hasTrustedIdentity}`);
-        if (requireTrustedIdentity && !hasTrustedIdentity) {
+        if (!hasTrustedIdentity) {
             const initiatedTime = Date.now();
             const cachedPairing: CachedPairing = {
                 uri: uri,
@@ -125,7 +123,6 @@ export const useWalletconnect = (
             console.log(cachedPairing);
             navigate("Bankid");
         } else {
-            console.log("uri", uri);
             try {
                 const pairResult = await client?.pair({ uri: uri });
                 console.log("pari", pairResult);


### PR DESCRIPTION
## Why?
Because we want to make the separation between UI-logic and business-logic clear. Decisions about where to navigate, when, should reside inside screens (UI-layer).

## Changelog
- Add / new hook `useLocalNavigation()`.
- refac / move navigation()-calls to `<Scanner/>`-screen.
- refac / remove unused `requireTrustedID`-parameter on `pair()`.
- refac / remove dead code in `BankID.tsx`.
- update `podfile.lock` and `project.pbxproj`.
