### PR TITLE
refactor: use identifier alias

### DIFF
--- a/src/utils/useVeramo.ts
+++ b/src/utils/useVeramo.ts
@@ -48,18 +48,11 @@ export const useVeramo = (chainId: string) => {
     useEffect(() => {
         const getIdentity = async () => {
             try {
-                const createIdentity = async () => {
-                    const identity = await agent.didManagerCreate({
-                        kms: "local",
-                        provider: "did:ethr:421611",
-                    });
-                    return identity;
-                };
-                const identifiers = await agent.didManagerFind();
-                if (identifiers.length === 0) {
-                    return await createIdentity();
-                }
-                return identifiers[0];
+                return await agent.didManagerGetOrCreate({
+                    alias: "default",
+                    kms: "local",
+                    provider: "did:ethr:421611",
+                });
             } catch (error) {
                 console.error(error);
             }


### PR DESCRIPTION
Avoid multiple lookups and parsing in app code:

- tag the default identifier with a `default` alias
- use getOrCreate method based on alias

You can query for the default identifier by using:

`
agent.didManagerGetByAlias({
    alias: 'default'
})
`